### PR TITLE
fix: refactor how services are filtered

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -38,7 +38,7 @@ auth_service_filter() {
 
   # this plugin trigger exists in the core `20_events` plugin
   if [[ "$user_auth_count" == 1 ]] && [[ -f "$PLUGIN_PATH"/enabled/20_events/user-auth-service ]]; then
-  # echo out all the services since there is no valid plugin trigger
+    # echo out all the services since there is no valid plugin trigger
     for SERVICE in "${SERVICES[@]}"; do
       [[ -n "$SERVICE" ]] && echo "$SERVICE"
     done
@@ -48,27 +48,36 @@ auth_service_filter() {
   export SSH_USER=${SSH_USER:=$USER}
   export SSH_NAME=${NAME:="default"}
   # the output of this trigger should be all the services a user has access to
-  plugn trigger user-auth-service "$SSH_USER" "$SSH_NAME" "${SERVICES[@]}"
+  plugn trigger user-auth-service "$SSH_USER" "$SSH_NAME" "$PLUGIN_COMMAND_PREFIX" "${SERVICES[@]}"
 }
 
 fn-services-list() {
   declare desc="prints a filtered list of all local apps"
   declare FILTER="$1"
-  local detected_services filtered_services services
+  local services=()
 
-  local detected_services=("$(ls "$PLUGIN_DATA_ROOT" 2>/dev/null)")
+  pushd "$PLUGIN_DATA_ROOT" >/dev/null
+  for f in *; do
+    [[ -d $f ]] || continue
+    services+=("$f")
+  done
+  popd &>/dev/null || pushd "/tmp" >/dev/null
+
+  if [[ "${#services[@]}" -eq 0 ]]; then
+    return
+  fi
+
   if [[ "$FILTER" == "false" ]]; then
-    for service in "${detected_services[@]}"; do
-      if [[ -n "$service" ]]; then 
+    for service in "${services[@]}"; do
+      if [[ -n "$service" ]]; then
         echo "$service"
       fi
     done
     return
   fi
 
-  filtered_services="$(auth_service_filter "${detected_services[@]}" 2>/dev/null)"
-  for service in "$filtered_services"; do
-    if [[ -n "$service" ]]; then 
+  for service in $(auth_service_filter "${services[@]}" 2>/dev/null); do
+    if [[ -n "$service" ]]; then
       echo "$service"
     fi
   done
@@ -94,7 +103,7 @@ get_database_name() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
 
   if [[ ! -f "$SERVICE_ROOT/DATABASE_NAME" ]]; then
-    echo "$SERVICE" > "$SERVICE_ROOT/DATABASE_NAME"
+    echo "$SERVICE" >"$SERVICE_ROOT/DATABASE_NAME"
   fi
 
   cat "$SERVICE_ROOT/DATABASE_NAME"
@@ -237,8 +246,7 @@ service_app_links() {
   declare APP="$1"
   local LINKED_APP SERVICE SERVICE_ROOT
 
-  pushd "$PLUGIN_DATA_ROOT" >/dev/null
-  for SERVICE in $(fn-services-list); do
+  for SERVICE in $(fn-services-list true); do
     [[ -n "$SERVICE" ]] || continue
 
     SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
@@ -308,7 +316,6 @@ service_commit_config() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local CONFIG_VARIABLE="${PLUGIN_VARIABLE}_CONFIG_OPTIONS"
   local ENV_VARIABLE="${PLUGIN_VARIABLE}_CUSTOM_ENV"
-
 
   custom_env="${!ENV_VARIABLE}"
   [[ -n "$SERVICE_CUSTOM_ENV" ]] && custom_env="$SERVICE_CUSTOM_ENV"
@@ -637,7 +644,7 @@ service_links() {
 service_list() {
   declare desc="list all services and their status"
 
-  services=("$(fn-services-list true)")
+  mapfile -t services < <(fn-services-list true)
   if [[ "${#services[@]}" -eq 0 ]] || [[ -z "$services" ]]; then
     dokku_log_warn "There are no $PLUGIN_SERVICE services"
     return
@@ -645,7 +652,7 @@ service_list() {
 
   dokku_log_info2_quiet "$PLUGIN_SERVICE services"
   for service in "${services[@]}"; do
-    echo "$service"
+    echo "${service}"
   done
 }
 
@@ -981,5 +988,5 @@ write_database_name() {
 
   # some datastores do not like special characters in database names
   # so we need to normalize them out
-  echo "$SERVICE" | tr .- _ > "$SERVICE_ROOT/DATABASE_NAME"
+  echo "$SERVICE" | tr .- _ >"$SERVICE_ROOT/DATABASE_NAME"
 }

--- a/subcommands/enter
+++ b/subcommands/enter
@@ -19,8 +19,8 @@ service-enter-cmd() {
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1"
 
-  dokku_log_info1_quiet "Filesystem changes may not persist after container restarts"
   verify_service_name "$SERVICE"
+  dokku_log_info1_quiet "Filesystem changes may not persist after container restarts"
   service_enter "$SERVICE" "${@:2}"
 }
 

--- a/tests/service_clone.bats
+++ b/tests/service_clone.bats
@@ -30,7 +30,7 @@ teardown() {
 @test "($PLUGIN_COMMAND_PREFIX:clone) error when new service already exists" {
   dokku "$PLUGIN_COMMAND_PREFIX:create" new_service
   run dokku "$PLUGIN_COMMAND_PREFIX:clone" ls new_service
-  assert_contains "${lines[*]}" "service new_service already exists"
+  assert_contains "${lines[*]}" "Invalid service name new_service"
   assert_failure
 
   dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" new_service


### PR DESCRIPTION
The previous method did not include the service type in the user-auth-service hook, which meant it was kinda guess/check as to whether a datastore was filtered correctly for the service in question.

Additionally, we now handle newlines correctly, ensuring that when there is filtering, we treat each datastore as a distinct one.